### PR TITLE
Add skeleton for FreeMoney Telegram bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TELEGRAM_TOKEN=your_telegram_bot_token
+DATABASE_PATH=db.sqlite3

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# FreeMoney Telegram Bot
+
+This project contains a simple Telegram bot for managing personal finance using a double-entry accounting approach. The bot is designed with modular structure and prepared for further development.
+
+## Features
+
+- Basic Telegram bot skeleton with main menu.
+- SQLite database with tables for accounts, account groups, account types and transactions.
+- `.env` configuration using `python-dotenv`.
+- `deploy.sh` script installs dependencies in a virtual environment and configures a systemd service.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your `TELEGRAM_TOKEN`.
+2. Run `python3 -m venv venv && source venv/bin/activate`.
+3. Install dependencies with `pip install -r requirements.txt`.
+4. Start the bot using `python bot-start-freemoney.py`.
+
+To deploy as a service on a server, use `./deploy.sh` with appropriate permissions.

--- a/bot-start-freemoney.py
+++ b/bot-start-freemoney.py
@@ -1,0 +1,6 @@
+from freemoney.bot import main
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Script to deploy and run the bot as a systemd service
+
+set -e
+
+APP_DIR=$(dirname $(readlink -f "$0"))
+VENV="$APP_DIR/venv"
+PYTHON="$VENV/bin/python"
+
+if [ ! -d "$VENV" ]; then
+    python3 -m venv "$VENV"
+fi
+
+"$PYTHON" -m pip install --upgrade pip
+"$PYTHON" -m pip install -r "$APP_DIR/requirements.txt"
+
+SERVICE_FILE="/etc/systemd/system/freemoney.service"
+
+echo "[Unit]" | sudo tee "$SERVICE_FILE" > /dev/null
+sudo tee -a "$SERVICE_FILE" > /dev/null <<EOF2
+Description=FreeMoney Telegram Bot
+After=network.target
+
+[Service]
+WorkingDirectory=$APP_DIR
+ExecStart=$PYTHON $APP_DIR/bot-start-freemoney.py
+Restart=always
+EnvironmentFile=$APP_DIR/.env
+
+[Install]
+WantedBy=multi-user.target
+EOF2
+
+sudo systemctl daemon-reload
+sudo systemctl enable freemoney.service
+sudo systemctl restart freemoney.service

--- a/freemoney/bot.py
+++ b/freemoney/bot.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from telegram import (
+    Update,
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+)
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    ConversationHandler,
+    MessageHandler,
+    filters,
+    CallbackQueryHandler,
+)
+
+from .config import get_settings
+from .database import Database
+from .init_data import seed
+
+
+MAIN_MENU, = range(1)
+
+
+class FinanceBot:
+    def __init__(self) -> None:
+        self.settings = get_settings()
+        self.db = Database(self.settings.database_path)
+
+    async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user_id = update.effective_user.id
+        seed(self.db, user_id)
+        await update.message.reply_text(
+            "Welcome to FreeMoney bot!",
+            reply_markup=self.main_menu_keyboard(),
+        )
+
+    def main_menu_keyboard(self) -> ReplyKeyboardMarkup:
+        buttons = [
+            [
+                KeyboardButton("Dashboard"),
+                KeyboardButton("Create transaction"),
+            ],
+            [
+                KeyboardButton("Transactions"),
+                KeyboardButton("Settings"),
+            ],
+        ]
+        return ReplyKeyboardMarkup(buttons, resize_keyboard=True)
+
+    async def handle_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        text = update.message.text
+        if text == "Dashboard":
+            await update.message.reply_text("Finance available: TODO")
+        elif text == "Create transaction":
+            await update.message.reply_text("Not implemented yet")
+        elif text == "Transactions":
+            await update.message.reply_text("Not implemented yet")
+        elif text == "Settings":
+            await update.message.reply_text("Not implemented yet")
+        else:
+            await update.message.reply_text(
+                "Use menu", reply_markup=self.main_menu_keyboard()
+            )
+
+    def build_app(self) -> Application:
+        application = Application.builder().token(self.settings.token).build()
+        application.add_handler(CommandHandler("start", self.start))
+        application.add_handler(
+            MessageHandler(
+                filters.TEXT & ~filters.COMMAND,
+                self.handle_menu,
+            )
+        )
+        return application
+
+
+async def main() -> None:
+    bot = FinanceBot()
+    application = bot.build_app()
+    await application.run_polling()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/freemoney/config.py
+++ b/freemoney/config.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from pathlib import Path
+from dotenv import load_dotenv
+import os
+
+
+@dataclass
+class Settings:
+    token: str
+    database_path: Path
+
+
+load_dotenv()
+
+def get_settings() -> Settings:
+    token = os.getenv("TELEGRAM_TOKEN")
+    if not token:
+        raise ValueError("TELEGRAM_TOKEN is not set")
+    db_path = Path(os.getenv("DATABASE_PATH", "db.sqlite3"))
+    return Settings(token=token, database_path=db_path)

--- a/freemoney/constants.py
+++ b/freemoney/constants.py
@@ -1,0 +1,40 @@
+ACCOUNT_TYPES = [
+    "assets",
+    "expenditures",
+    "liabilities",
+    "income",
+    "capital",
+]
+
+ACCOUNT_GROUPS = {
+    "assets": [
+        "cash",
+        "bank accounts",
+        "bank deposits",
+        "debit card",
+        "credit card",
+        "fixed assets",
+    ],
+    "expenditures": [
+        "Education",
+        "Living space",
+        "Entertainment",
+        "Transport",
+        "Health & Sport",
+        "Culture",
+        "Digital",
+        "Electronics",
+        "Apparel",
+    ],
+    "liabilities": [
+        "Mortgage",
+    ],
+    "income": [
+        "Salary",
+    ],
+    "capital": [
+        "Initial values",
+        "Monthly result",
+        "Corrections",
+    ],
+}

--- a/freemoney/database.py
+++ b/freemoney/database.py
@@ -1,0 +1,75 @@
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Tuple
+
+
+SCHEMA = [
+    """
+    CREATE TABLE IF NOT EXISTS account_types (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT UNIQUE NOT NULL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS account_groups (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        type_id INTEGER NOT NULL REFERENCES account_types(id),
+        name TEXT NOT NULL
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS accounts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        group_id INTEGER NOT NULL REFERENCES account_groups(id),
+        name TEXT NOT NULL,
+        archived INTEGER DEFAULT 0
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS transactions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        from_account INTEGER NOT NULL REFERENCES accounts(id),
+        to_account INTEGER NOT NULL REFERENCES accounts(id),
+        amount REAL NOT NULL,
+        ts DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS settings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        key TEXT NOT NULL,
+        value TEXT
+    );
+    """,
+]
+
+
+class Database:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.conn = sqlite3.connect(self.path)
+        self.conn.row_factory = sqlite3.Row
+        self._initialize()
+
+    def _initialize(self) -> None:
+        cur = self.conn.cursor()
+        for stmt in SCHEMA:
+            cur.execute(stmt)
+        self.conn.commit()
+
+    def execute(self, query: str, params: Iterable = ()):  # simple wrapper
+        cur = self.conn.execute(query, params)
+        self.conn.commit()
+        return cur
+
+    def fetchall(self, query: str, params: Iterable = ()) -> Iterable[sqlite3.Row]:
+        cur = self.conn.execute(query, params)
+        return cur.fetchall()
+
+    def fetchone(self, query: str, params: Iterable = ()) -> sqlite3.Row | None:
+        cur = self.conn.execute(query, params)
+        return cur.fetchone()

--- a/freemoney/init_data.py
+++ b/freemoney/init_data.py
@@ -1,0 +1,27 @@
+from .database import Database
+from .constants import ACCOUNT_TYPES, ACCOUNT_GROUPS
+
+
+def seed(db: Database, user_id: int) -> None:
+    """Initialize account types and groups for a user if not present."""
+    for atype in ACCOUNT_TYPES:
+        db.execute(
+            "INSERT OR IGNORE INTO account_types (name) VALUES (?)",
+            (atype,),
+        )
+    for atype, groups in ACCOUNT_GROUPS.items():
+        type_row = db.fetchone(
+            "SELECT id FROM account_types WHERE name=?",
+            (atype,),
+        )
+        if not type_row:
+            continue
+        type_id = type_row["id"]
+        for group in groups:
+            db.execute(
+                """
+                INSERT OR IGNORE INTO account_groups (user_id, type_id, name)
+                VALUES (?, ?, ?)
+                """,
+                (user_id, type_id, group),
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot==20.5
+python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- initialize python package with modular bot code
- add SQLite database wrapper and default account types/groups
- configure settings with dotenv
- provide deploy script for systemd deployment
- add example environment file and README

## Testing
- `python -m py_compile freemoney/*.py bot-start-freemoney.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6855c2a643f88332aa320bb9d3eae383