### PR TITLE
Fix event loop error by using synchronous run_polling

### DIFF
--- a/bot-start-freemoney.py
+++ b/bot-start-freemoney.py
@@ -1,6 +1,4 @@
 from freemoney.bot import main
 
 if __name__ == "__main__":
-    import asyncio
-
-    asyncio.run(main())
+    main()

--- a/freemoney/bot.py
+++ b/freemoney/bot.py
@@ -78,13 +78,11 @@ class FinanceBot:
         return application
 
 
-async def main() -> None:
+def main() -> None:
     bot = FinanceBot()
     application = bot.build_app()
-    await application.run_polling()
+    application.run_polling()
 
 
 if __name__ == "__main__":
-    import asyncio
-
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
## Summary
- remove `asyncio.run()` usage
- call `Application.run_polling()` directly

## Testing
- `python bot-start-freemoney.py 2>&1 | head -n 20` *(fails: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_685686a7f4dc833280483203fcf84810