### PR TITLE
Fix PTBUserWarning by tracking per message

### DIFF
--- a/freemoney/bot.py
+++ b/freemoney/bot.py
@@ -357,6 +357,7 @@ class FinanceBot:
                 SUMMARY: [CallbackQueryHandler(self.summary_action, pattern="^(edit|delete)$")],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
+            per_message=True,
         )
         application.add_handler(create_tx_conv)
 
@@ -368,6 +369,7 @@ class FinanceBot:
                 TX_EDIT_AMOUNT: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.tx_edit_amount)],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
+            per_message=True,
         )
         application.add_handler(tx_conv)
 


### PR DESCRIPTION
## Summary
- enable per-message tracking for conversation handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68568adfe7248332b55a798bc6b0596c