### PR TITLE
Fix account group duplicates and allow conversation reentry

### DIFF
--- a/freemoney/bot.py
+++ b/freemoney/bot.py
@@ -358,6 +358,7 @@ class FinanceBot:
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
             per_message=True,
+            allow_reentry=True,
         )
         application.add_handler(create_tx_conv)
 

--- a/freemoney/database.py
+++ b/freemoney/database.py
@@ -15,7 +15,8 @@ SCHEMA = [
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         user_id INTEGER NOT NULL,
         type_id INTEGER NOT NULL REFERENCES account_types(id),
-        name TEXT NOT NULL
+        name TEXT NOT NULL,
+        UNIQUE(user_id, type_id, name)
     );
     """,
     """

--- a/freemoney/init_data.py
+++ b/freemoney/init_data.py
@@ -18,10 +18,15 @@ def seed(db: Database, user_id: int) -> None:
             continue
         type_id = type_row["id"]
         for group in groups:
-            db.execute(
-                """
-                INSERT OR IGNORE INTO account_groups (user_id, type_id, name)
-                VALUES (?, ?, ?)
-                """,
+            exists = db.fetchone(
+                "SELECT 1 FROM account_groups WHERE user_id=? AND type_id=? AND name=?",
                 (user_id, type_id, group),
             )
+            if not exists:
+                db.execute(
+                    """
+                    INSERT INTO account_groups (user_id, type_id, name)
+                    VALUES (?, ?, ?)
+                    """,
+                    (user_id, type_id, group),
+                )


### PR DESCRIPTION
## Summary
- prevent duplicate account group names
- enforce unique (user_id, type_id, name) in DB
- allow restarting transaction creation while a conversation is active

## Testing
- `python -m py_compile freemoney/*.py`
- `pytest -q`
- `flake8 freemoney | head`

------
https://chatgpt.com/codex/tasks/task_e_68568bfd67488332b3da27ae329dea90