### PR TITLE
Remove per_message flag from conversation handlers

### DIFF
--- a/freemoney/bot.py
+++ b/freemoney/bot.py
@@ -663,7 +663,6 @@ class FinanceBot:
                 SUMMARY: [CallbackQueryHandler(self.summary_action, pattern="^(edit|delete)$")],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
-            per_message=True,
             allow_reentry=True,
         )
         application.add_handler(create_tx_conv)
@@ -676,7 +675,6 @@ class FinanceBot:
                 TX_EDIT_AMOUNT: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.tx_edit_amount)],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
-            per_message=True,
         )
         application.add_handler(tx_conv)
 
@@ -717,7 +715,6 @@ class FinanceBot:
                 ACCOUNT_RENAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.account_rename)],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
-            per_message=True,
         )
         application.add_handler(settings_conv)
 


### PR DESCRIPTION
## Summary
- fix PTB warnings by removing `per_message=True` from the ConversationHandlers

## Testing
- `python -m py_compile freemoney/bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68569028a2a08332865b3f467f7d5d9e