### PR TITLE
Improve transaction creation UX

### DIFF
--- a/foremoney/bot.py
+++ b/foremoney/bot.py
@@ -37,24 +37,12 @@ class FinanceBot(
         create_tx_conv = ConversationHandler(
             entry_points=[MessageHandler(filters.Regex("^Create transaction$"), self.start_create_transaction)],
             states={
-                FROM_TYPE: [CallbackQueryHandler(self.from_type, pattern="^ftype:")],
-                FROM_GROUP: [
-                    CallbackQueryHandler(self.from_group, pattern="^fgroup:"),
-                    CallbackQueryHandler(self.add_account_prompt, pattern="^addacc:from:"),
-                ],
-                FROM_ACCOUNT: [
-                    CallbackQueryHandler(self.from_account, pattern="^facc:"),
-                    CallbackQueryHandler(self.add_account_prompt, pattern="^addacc:from:"),
-                ],
-                TO_TYPE: [CallbackQueryHandler(self.to_type, pattern="^ttype:")],
-                TO_GROUP: [
-                    CallbackQueryHandler(self.to_group, pattern="^tgroup:"),
-                    CallbackQueryHandler(self.add_account_prompt, pattern="^addacc:to:"),
-                ],
-                TO_ACCOUNT: [
-                    CallbackQueryHandler(self.to_account, pattern="^tacc:"),
-                    CallbackQueryHandler(self.add_account_prompt, pattern="^addacc:to:"),
-                ],
+                FROM_TYPE: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.from_type)],
+                FROM_GROUP: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.from_group)],
+                FROM_ACCOUNT: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.from_account)],
+                TO_TYPE: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.to_type)],
+                TO_GROUP: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.to_group)],
+                TO_ACCOUNT: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.to_account)],
                 AMOUNT: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.amount)],
                 ADD_ACCOUNT_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.add_account_name)],
                 SUMMARY: [CallbackQueryHandler(self.summary_action, pattern="^(edit|delete)$")],

--- a/foremoney/transactions_create.py
+++ b/foremoney/transactions_create.py
@@ -1,7 +1,14 @@
-from telegram import Update, InlineKeyboardButton
-from telegram.ext import ContextTypes
+from telegram import (
+    Update,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    ReplyKeyboardRemove,
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+)
+from telegram.ext import ContextTypes, ConversationHandler
 
-from .ui import items_keyboard
+from .ui import items_reply_keyboard
 from .states import (
     FROM_TYPE, FROM_GROUP, FROM_ACCOUNT,
     TO_TYPE, TO_GROUP, TO_ACCOUNT,
@@ -13,113 +20,247 @@ class TransactionCreateMixin:
 
     async def start_create_transaction(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         types = self.db.account_types()
+        context.user_data["from_type_map"] = {t["name"]: t["id"] for t in types}
         await update.message.reply_text(
             "Select source account type",
-            reply_markup=items_keyboard(types, "ftype"),
+            reply_markup=items_reply_keyboard(types, ["Cancel"]),
         )
         return FROM_TYPE
 
     async def from_type(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        query = update.callback_query
-        await query.answer()
-        type_id = int(query.data.split(":")[1])
+        text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
+        type_map = context.user_data.get("from_type_map", {})
+        if text not in type_map:
+            await update.message.reply_text("Use provided buttons")
+            return FROM_TYPE
+        type_id = type_map[text]
         context.user_data["from_type"] = type_id
         groups = self.db.account_groups(update.effective_user.id, type_id)
-        await query.message.reply_text(
+        context.user_data["from_group_map"] = {g["name"]: g["id"] for g in groups}
+        await update.message.reply_text(
             "Select source account group",
-            reply_markup=items_keyboard(groups, "fgroup"),
+            reply_markup=items_reply_keyboard(groups, ["Back", "Cancel"]),
         )
         return FROM_GROUP
 
     async def from_group(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        query = update.callback_query
-        await query.answer()
-        group_id = int(query.data.split(":")[1])
+        text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
+        if text == "Back":
+            return await self.start_create_transaction(update, context)
+        group_map = context.user_data.get("from_group_map", {})
+        if text not in group_map:
+            await update.message.reply_text("Use provided buttons")
+            return FROM_GROUP
+        group_id = group_map[text]
         context.user_data["from_group"] = group_id
         accounts = self.db.accounts(update.effective_user.id, group_id)
-        extra = [InlineKeyboardButton("+", callback_data=f"addacc:from:{group_id}")]
-        await query.message.reply_text(
+        context.user_data["from_account_map"] = {a["name"]: a["id"] for a in accounts}
+        context.user_data["account_prefix"] = "from"
+        await update.message.reply_text(
             "Select source account",
-            reply_markup=items_keyboard(accounts, "facc", extra_buttons=extra),
+            reply_markup=items_reply_keyboard(accounts, ["+ account", "Back", "Cancel"]),
         )
         return FROM_ACCOUNT
 
-    async def add_account_prompt(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        query = update.callback_query
-        await query.answer()
-        _, prefix, gid = query.data.split(":")
-        context.user_data["add_prefix"] = prefix
-        context.user_data["add_group"] = int(gid)
-        await query.message.reply_text("Enter account name")
-        return ADD_ACCOUNT_NAME
 
     async def add_account_name(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        name = update.message.text.strip()
+        text = update.message.text.strip()
         gid = context.user_data["add_group"]
         prefix = context.user_data["add_prefix"]
         user_id = update.effective_user.id
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
+        if text == "Back":
+            accounts = self.db.accounts(user_id, gid)
+            acc_map_key = "from_account_map" if prefix == "from" else "to_account_map"
+            context.user_data[acc_map_key] = {a["name"]: a["id"] for a in accounts}
+            context.user_data["account_prefix"] = prefix
+            await update.message.reply_text(
+                "Select account",
+                reply_markup=items_reply_keyboard(accounts, ["+ account", "Back", "Cancel"]),
+            )
+            return FROM_ACCOUNT if prefix == "from" else TO_ACCOUNT
+        name = text
         self.db.add_account(user_id, gid, name)
         accounts = self.db.accounts(user_id, gid)
-        extra = [InlineKeyboardButton("+", callback_data=f"addacc:{prefix}:{gid}")]
+        acc_map_key = "from_account_map" if prefix == "from" else "to_account_map"
+        context.user_data[acc_map_key] = {a["name"]: a["id"] for a in accounts}
+        context.user_data["account_prefix"] = prefix
         await update.message.reply_text(
             "Select account",
-            reply_markup=items_keyboard(
-                accounts,
-                "facc" if prefix == "from" else "tacc",
-                extra_buttons=extra,
-            ),
+            reply_markup=items_reply_keyboard(accounts, ["+ account", "Back", "Cancel"]),
         )
         return FROM_ACCOUNT if prefix == "from" else TO_ACCOUNT
 
     async def from_account(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        query = update.callback_query
-        await query.answer()
-        account_id = int(query.data.split(":")[1])
+        text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
+        if text == "Back":
+            groups = self.db.account_groups(
+                update.effective_user.id, context.user_data["from_type"]
+            )
+            context.user_data["from_group_map"] = {g["name"]: g["id"] for g in groups}
+            await update.message.reply_text(
+                "Select source account group",
+                reply_markup=items_reply_keyboard(groups, ["Back", "Cancel"]),
+            )
+            return FROM_GROUP
+        if text == "+ account":
+            context.user_data["add_prefix"] = context.user_data.get("account_prefix")
+            context.user_data["add_group"] = context.user_data["from_group"]
+            await update.message.reply_text("Enter account name", reply_markup=ReplyKeyboardRemove())
+            return ADD_ACCOUNT_NAME
+        acc_map = context.user_data.get("from_account_map", {})
+        if text not in acc_map:
+            await update.message.reply_text("Use provided buttons")
+            return FROM_ACCOUNT
+        account_id = acc_map[text]
         context.user_data["from_account"] = account_id
         types = self.db.account_types()
-        await query.message.reply_text(
+        context.user_data["to_type_map"] = {t["name"]: t["id"] for t in types}
+        await update.message.reply_text(
             "Select destination account type",
-            reply_markup=items_keyboard(types, "ttype"),
+            reply_markup=items_reply_keyboard(types, ["Back", "Cancel"]),
         )
         return TO_TYPE
 
     async def to_type(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        query = update.callback_query
-        await query.answer()
-        type_id = int(query.data.split(":")[1])
+        text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
+        if text == "Back":
+            accounts = self.db.accounts(
+                update.effective_user.id, context.user_data["from_group"]
+            )
+            context.user_data["from_account_map"] = {a["name"]: a["id"] for a in accounts}
+            context.user_data["account_prefix"] = "from"
+            await update.message.reply_text(
+                "Select source account",
+                reply_markup=items_reply_keyboard(accounts, ["+ account", "Back", "Cancel"]),
+            )
+            return FROM_ACCOUNT
+        type_map = context.user_data.get("to_type_map", {})
+        if text not in type_map:
+            await update.message.reply_text("Use provided buttons")
+            return TO_TYPE
+        type_id = type_map[text]
         context.user_data["to_type"] = type_id
         groups = self.db.account_groups(update.effective_user.id, type_id)
-        await query.message.reply_text(
+        context.user_data["to_group_map"] = {g["name"]: g["id"] for g in groups}
+        await update.message.reply_text(
             "Select destination account group",
-            reply_markup=items_keyboard(groups, "tgroup"),
+            reply_markup=items_reply_keyboard(groups, ["Back", "Cancel"]),
         )
         return TO_GROUP
 
     async def to_group(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        query = update.callback_query
-        await query.answer()
-        group_id = int(query.data.split(":")[1])
+        text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
+        if text == "Back":
+            types = self.db.account_types()
+            context.user_data["to_type_map"] = {t["name"]: t["id"] for t in types}
+            await update.message.reply_text(
+                "Select destination account type",
+                reply_markup=items_reply_keyboard(types, ["Back", "Cancel"]),
+            )
+            return TO_TYPE
+        group_map = context.user_data.get("to_group_map", {})
+        if text not in group_map:
+            await update.message.reply_text("Use provided buttons")
+            return TO_GROUP
+        group_id = group_map[text]
         context.user_data["to_group"] = group_id
         accounts = self.db.accounts(update.effective_user.id, group_id)
-        extra = [InlineKeyboardButton("+", callback_data=f"addacc:to:{group_id}")]
-        await query.message.reply_text(
+        context.user_data["to_account_map"] = {a["name"]: a["id"] for a in accounts}
+        context.user_data["account_prefix"] = "to"
+        await update.message.reply_text(
             "Select destination account",
-            reply_markup=items_keyboard(accounts, "tacc", extra_buttons=extra),
+            reply_markup=items_reply_keyboard(accounts, ["+ account", "Back", "Cancel"]),
         )
         return TO_ACCOUNT
 
     async def to_account(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        query = update.callback_query
-        await query.answer()
-        account_id = int(query.data.split(":")[1])
+        text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
+        if text == "Back":
+            groups = self.db.account_groups(
+                update.effective_user.id, context.user_data["to_type"]
+            )
+            context.user_data["to_group_map"] = {g["name"]: g["id"] for g in groups}
+            await update.message.reply_text(
+                "Select destination account group",
+                reply_markup=items_reply_keyboard(groups, ["Back", "Cancel"]),
+            )
+            return TO_GROUP
+        if text == "+ account":
+            context.user_data["add_prefix"] = context.user_data.get("account_prefix")
+            context.user_data["add_group"] = context.user_data["to_group"]
+            await update.message.reply_text("Enter account name", reply_markup=ReplyKeyboardRemove())
+            return ADD_ACCOUNT_NAME
+        acc_map = context.user_data.get("to_account_map", {})
+        if text not in acc_map:
+            await update.message.reply_text("Use provided buttons")
+            return TO_ACCOUNT
+        account_id = acc_map[text]
         context.user_data["to_account"] = account_id
-        await query.message.reply_text("Enter amount")
+        await update.message.reply_text(
+            "Enter amount",
+            reply_markup=ReplyKeyboardMarkup(
+                [[KeyboardButton("Back"), KeyboardButton("Cancel")]],
+                resize_keyboard=True,
+            ),
+        )
         context.user_data.pop("editing", None)
         return AMOUNT
 
     async def amount(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
+        if text == "Back":
+            accounts = self.db.accounts(
+                update.effective_user.id, context.user_data["to_group"]
+            )
+            context.user_data["to_account_map"] = {a["name"]: a["id"] for a in accounts}
+            context.user_data["account_prefix"] = "to"
+            await update.message.reply_text(
+                "Select destination account",
+                reply_markup=items_reply_keyboard(accounts, ["+ account", "Back", "Cancel"]),
+            )
+            return TO_ACCOUNT
         try:
-            amount = float(update.message.text)
+            amount = float(text)
         except ValueError:
             await update.message.reply_text("Please enter a number")
             return AMOUNT

--- a/foremoney/ui.py
+++ b/foremoney/ui.py
@@ -1,4 +1,9 @@
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+)
 from typing import Iterable, Mapping, Sequence
 
 
@@ -17,3 +22,18 @@ def items_keyboard(items: Iterable[Mapping], prefix: str, extra_buttons: Sequenc
         for btn in extra_buttons:
             buttons.append([btn])
     return InlineKeyboardMarkup(buttons)
+
+
+def items_reply_keyboard(
+    items: Iterable[Mapping],
+    extra_labels: Sequence[str] | None = None,
+) -> ReplyKeyboardMarkup:
+    """Create ReplyKeyboardMarkup from DB rows.
+
+    ``items`` should be an iterable of mappings with at least ``name`` key.
+    ``extra_labels`` if provided will be appended as last row of buttons.
+    """
+    buttons = [[KeyboardButton(str(item["name"]))] for item in items]
+    if extra_labels:
+        buttons.append([KeyboardButton(lbl) for lbl in extra_labels])
+    return ReplyKeyboardMarkup(buttons, resize_keyboard=True)


### PR DESCRIPTION
## Summary
- make item selection use reply keyboards
- add Back and Cancel buttons with proper behavior
- update conversation handlers for new input method

## Testing
- `python -m py_compile foremoney/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6856a5a9a4c48332969bec405fb32b9b