### PR TITLE
Fix transactions menu reentry

### DIFF
--- a/foremoney/bot.py
+++ b/foremoney/bot.py
@@ -59,6 +59,7 @@ class FinanceBot(
                 TX_EDIT_AMOUNT: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.tx_edit_amount)],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
+            allow_reentry=True,
         )
         application.add_handler(tx_conv)
 


### PR DESCRIPTION
## Summary
- allow reentering Transactions conversation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6856b37ba3e48332a4d35ad1daa0d2fe