### PR TITLE
Show account group and type totals

### DIFF
--- a/foremoney/database.py
+++ b/foremoney/database.py
@@ -261,6 +261,38 @@ class Database:
             result.append({"id": a["id"], "name": a["name"], "value": val})
         return result
 
+    def account_group_value(self, user_id: int, group_id: int) -> float:
+        """Return total value of all accounts within a group."""
+        total = 0.0
+        for acc in self.accounts(user_id, group_id):
+            total += self.account_value(user_id, acc["id"])
+        return total
+
+    def account_groups_with_value(self, user_id: int, type_id: int):
+        """Return account groups list with calculated values."""
+        groups = self.account_groups(user_id, type_id)
+        result = []
+        for g in groups:
+            val = self.account_group_value(user_id, g["id"])
+            result.append({"id": g["id"], "name": g["name"], "value": val})
+        return result
+
+    def account_type_value(self, user_id: int, type_id: int) -> float:
+        """Return total value of all accounts within a type."""
+        total = 0.0
+        for g in self.account_groups(user_id, type_id):
+            total += self.account_group_value(user_id, g["id"])
+        return total
+
+    def account_types_with_value(self, user_id: int):
+        """Return account types list with calculated values."""
+        types = self.account_types()
+        result = []
+        for t in types:
+            val = self.account_type_value(user_id, t["id"])
+            result.append({"id": t["id"], "name": t["name"], "value": val})
+        return result
+
     def accounts_balance(self, user_id: int, account_ids: Iterable[int]) -> float:
         total = 0.0
         for aid in account_ids:

--- a/foremoney/transactions_create.py
+++ b/foremoney/transactions_create.py
@@ -24,11 +24,15 @@ class TransactionCreateMixin:
     """Flow for creating a transaction."""
 
     async def start_create_transaction(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        types = self.db.account_types()
-        context.user_data["from_type_map"] = {t["name"]: t["id"] for t in types}
+        user_id = update.effective_user.id
+        types = self.db.account_types_with_value(user_id)
+        type_labels = [
+            {"id": t["id"], "name": f"{t['name']} ({t['value']})"} for t in types
+        ]
+        context.user_data["from_type_map"] = {lbl["name"]: lbl["id"] for lbl in type_labels}
         await update.message.reply_text(
             "Select source account type",
-            reply_markup=items_reply_keyboard(types, ["Cancel"], columns=2),
+            reply_markup=items_reply_keyboard(type_labels, ["Cancel"], columns=2),
         )
         return FROM_TYPE
 
@@ -45,11 +49,15 @@ class TransactionCreateMixin:
             return FROM_TYPE
         type_id = type_map[text]
         context.user_data["from_type"] = type_id
-        groups = self.db.account_groups(update.effective_user.id, type_id)
-        context.user_data["from_group_map"] = {g["name"]: g["id"] for g in groups}
+        user_id = update.effective_user.id
+        groups = self.db.account_groups_with_value(user_id, type_id)
+        group_labels = [
+            {"id": g["id"], "name": f"{g['name']} ({g['value']})"} for g in groups
+        ]
+        context.user_data["from_group_map"] = {lbl["name"]: lbl["id"] for lbl in group_labels}
         await update.message.reply_text(
             "Select source account group",
-            reply_markup=items_reply_keyboard(groups, ["Back", "Cancel"], columns=2),
+            reply_markup=items_reply_keyboard(group_labels, ["Back", "Cancel"], columns=2),
         )
         return FROM_GROUP
 
@@ -123,13 +131,17 @@ class TransactionCreateMixin:
             )
             return ConversationHandler.END
         if text == "Back":
-            groups = self.db.account_groups(
-                update.effective_user.id, context.user_data["from_type"]
+            user_id = update.effective_user.id
+            groups = self.db.account_groups_with_value(
+                user_id, context.user_data["from_type"]
             )
-            context.user_data["from_group_map"] = {g["name"]: g["id"] for g in groups}
+            group_labels = [
+                {"id": g["id"], "name": f"{g['name']} ({g['value']})"} for g in groups
+            ]
+            context.user_data["from_group_map"] = {lbl["name"]: lbl["id"] for lbl in group_labels}
             await update.message.reply_text(
                 "Select source account group",
-                reply_markup=items_reply_keyboard(groups, ["Back", "Cancel"], columns=2),
+                reply_markup=items_reply_keyboard(group_labels, ["Back", "Cancel"], columns=2),
             )
             return FROM_GROUP
         if text == "+ account":
@@ -143,11 +155,15 @@ class TransactionCreateMixin:
             return FROM_ACCOUNT
         account_id = acc_map[text]
         context.user_data["from_account"] = account_id
-        types = self.db.account_types()
-        context.user_data["to_type_map"] = {t["name"]: t["id"] for t in types}
+        user_id = update.effective_user.id
+        types = self.db.account_types_with_value(user_id)
+        type_labels = [
+            {"id": t["id"], "name": f"{t['name']} ({t['value']})"} for t in types
+        ]
+        context.user_data["to_type_map"] = {lbl["name"]: lbl["id"] for lbl in type_labels}
         await update.message.reply_text(
             "Select destination account type",
-            reply_markup=items_reply_keyboard(types, ["Back", "Cancel"], columns=2),
+            reply_markup=items_reply_keyboard(type_labels, ["Back", "Cancel"], columns=2),
         )
         return TO_TYPE
 
@@ -176,11 +192,15 @@ class TransactionCreateMixin:
             return TO_TYPE
         type_id = type_map[text]
         context.user_data["to_type"] = type_id
-        groups = self.db.account_groups(update.effective_user.id, type_id)
-        context.user_data["to_group_map"] = {g["name"]: g["id"] for g in groups}
+        user_id = update.effective_user.id
+        groups = self.db.account_groups_with_value(user_id, type_id)
+        group_labels = [
+            {"id": g["id"], "name": f"{g['name']} ({g['value']})"} for g in groups
+        ]
+        context.user_data["to_group_map"] = {lbl["name"]: lbl["id"] for lbl in group_labels}
         await update.message.reply_text(
             "Select destination account group",
-            reply_markup=items_reply_keyboard(groups, ["Back", "Cancel"], columns=2),
+            reply_markup=items_reply_keyboard(group_labels, ["Back", "Cancel"], columns=2),
         )
         return TO_GROUP
 
@@ -192,11 +212,15 @@ class TransactionCreateMixin:
             )
             return ConversationHandler.END
         if text == "Back":
-            types = self.db.account_types()
-            context.user_data["to_type_map"] = {t["name"]: t["id"] for t in types}
+            user_id = update.effective_user.id
+            types = self.db.account_types_with_value(user_id)
+            type_labels = [
+                {"id": t["id"], "name": f"{t['name']} ({t['value']})"} for t in types
+            ]
+            context.user_data["to_type_map"] = {lbl["name"]: lbl["id"] for lbl in type_labels}
             await update.message.reply_text(
                 "Select destination account type",
-                reply_markup=items_reply_keyboard(types, ["Back", "Cancel"], columns=2),
+                reply_markup=items_reply_keyboard(type_labels, ["Back", "Cancel"], columns=2),
             )
             return TO_TYPE
         group_map = context.user_data.get("to_group_map", {})
@@ -223,13 +247,17 @@ class TransactionCreateMixin:
             )
             return ConversationHandler.END
         if text == "Back":
-            groups = self.db.account_groups(
-                update.effective_user.id, context.user_data["to_type"]
+            user_id = update.effective_user.id
+            groups = self.db.account_groups_with_value(
+                user_id, context.user_data["to_type"]
             )
-            context.user_data["to_group_map"] = {g["name"]: g["id"] for g in groups}
+            group_labels = [
+                {"id": g["id"], "name": f"{g['name']} ({g['value']})"} for g in groups
+            ]
+            context.user_data["to_group_map"] = {lbl["name"]: lbl["id"] for lbl in group_labels}
             await update.message.reply_text(
                 "Select destination account group",
-                reply_markup=items_reply_keyboard(groups, ["Back", "Cancel"], columns=2),
+                reply_markup=items_reply_keyboard(group_labels, ["Back", "Cancel"], columns=2),
             )
             return TO_GROUP
         if text == "+ account":


### PR DESCRIPTION
## Summary
- show total values for account types and groups
- aggregate account values in database helpers

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856c692d5e083329f87b7514ad48d24