### PR TITLE
Seed account types when needed

### DIFF
--- a/foremoney/menu.py
+++ b/foremoney/menu.py
@@ -96,6 +96,7 @@ class MenuMixin:
             )
             return DASH_MENU
         if text == "Accounts":
+            seed(self.db, user_id)
             types = self.db.account_types_with_value(user_id)
             type_labels = [
                 {"id": t["id"], "name": f"{t['name']} ({t['value']})"} for t in types

--- a/foremoney/settings_groups.py
+++ b/foremoney/settings_groups.py
@@ -1,6 +1,8 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
+from .init_data import seed
+
 from .ui import items_keyboard
 from .states import (
     AG_TYPE_SELECT, AG_GROUPS, AG_GROUP_RENAME, AG_ADD_GROUP_NAME,
@@ -21,7 +23,9 @@ class SettingsGroupsMixin:
         return InlineKeyboardMarkup(buttons)
 
     async def start_account_groups(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        types = self.db.account_types_with_value(update.effective_user.id)
+        user_id = update.effective_user.id
+        seed(self.db, user_id)
+        types = self.db.account_types_with_value(user_id)
         type_labels = [
             {"id": t["id"], "name": f"{t['name']} ({t['value']})"} for t in types
         ]

--- a/foremoney/transactions_create.py
+++ b/foremoney/transactions_create.py
@@ -9,6 +9,7 @@ from telegram import (
 from telegram.ext import ContextTypes, ConversationHandler
 
 from .ui import items_reply_keyboard
+from .init_data import seed
 from .states import (
     FROM_TYPE,
     FROM_GROUP,
@@ -26,6 +27,7 @@ class TransactionCreateMixin:
 
     async def start_create_transaction(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         user_id = update.effective_user.id
+        seed(self.db, user_id)
         types = self.db.account_types_with_value(user_id)
         type_labels = [
             {"id": t["id"], "name": f"{t['name']} ({t['value']})"} for t in types


### PR DESCRIPTION
## Summary
- ensure account types and groups are seeded when starting account related flows
- import and invoke `seed` before showing lists of account types

## Testing
- `python -m py_compile foremoney/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6856ebb2ab1483328eea7a2f450a9f34