### PR TITLE
Fix dashboard submenu layout

### DIFF
--- a/foremoney/menu.py
+++ b/foremoney/menu.py
@@ -57,10 +57,8 @@ class MenuMixin:
 
     def dashboard_menu_keyboard(self) -> ReplyKeyboardMarkup:
         buttons = [
-            [KeyboardButton("Cash available")],
-            [KeyboardButton("Accounts")],
-            [KeyboardButton("Forecast")],
-            [KeyboardButton("Back")],
+            [KeyboardButton("Cash available"), KeyboardButton("Accounts")],
+            [KeyboardButton("Forecast"), KeyboardButton("Back")],
         ]
         return ReplyKeyboardMarkup(buttons, resize_keyboard=True)
 


### PR DESCRIPTION
## Summary
- arrange Dashboard submenu buttons into two columns for better layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 | head -n 20` *(fails: E501 line too long, F405 star imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6856f60c54c88332971b2239b3c92c25