### PR TITLE
Implement dashboard group submenu

### DIFF
--- a/foremoney/bot.py
+++ b/foremoney/bot.py
@@ -70,6 +70,8 @@ class FinanceBot(
                 DASH_MENU: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.dashboard_menu)],
                 DASH_ACC_TYPE: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.dashboard_acc_type)],
                 DASH_ACC_MENU: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.dashboard_acc_menu)],
+                DASH_GROUP_SELECT: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.dashboard_group_select)],
+                DASH_GROUP_MENU: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.dashboard_group_menu)],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
         )

--- a/foremoney/database.py
+++ b/foremoney/database.py
@@ -362,3 +362,23 @@ class Database:
             """,
             (user_id, type_id, type_id),
         )
+
+    def account_group_transactions(self, user_id: int, group_id: int):
+        """Return transactions affecting given account group ordered by time."""
+        return self.fetchall(
+            """
+            SELECT t.ts, t.amount,
+                   ftype.name AS from_type, ttype.name AS to_type,
+                   fg.id AS from_group_id, tg.id AS to_group_id
+            FROM transactions t
+            JOIN accounts fa ON fa.id=t.from_account
+            JOIN account_groups fg ON fa.group_id=fg.id
+            JOIN account_types ftype ON fg.type_id=ftype.id
+            JOIN accounts ta ON ta.id=t.to_account
+            JOIN account_groups tg ON ta.group_id=tg.id
+            JOIN account_types ttype ON tg.type_id=ttype.id
+            WHERE t.user_id=? AND (fg.id=? OR tg.id=?)
+            ORDER BY t.ts, t.id
+            """,
+            (user_id, group_id, group_id),
+        )

--- a/foremoney/states.py
+++ b/foremoney/states.py
@@ -26,4 +26,6 @@
     DASH_MENU,
     DASH_ACC_TYPE,
     DASH_ACC_MENU,
-) = range(26)
+    DASH_GROUP_SELECT,
+    DASH_GROUP_MENU,
+) = range(28)


### PR DESCRIPTION
## Summary
- add conversation states for dashboard groups
- implement account group transactions query
- add dashboard group list and menu handlers
- wire group submenu into main dashboard flow

## Testing
- `python -m py_compile foremoney/*.py`
- `python -m py_compile bot-start-foremoney.py`

------
https://chatgpt.com/codex/tasks/task_e_6856fca1cf7083328b0c6bb81f0af0ec