### PR TITLE
Arrange dashboard submenus 2 columns

### DIFF
--- a/foremoney/menu.py
+++ b/foremoney/menu.py
@@ -66,19 +66,17 @@ class MenuMixin:
 
     def dashboard_account_menu_keyboard(self) -> ReplyKeyboardMarkup:
         buttons = [
-            [KeyboardButton("Account groups")],
-            [KeyboardButton("Structure")],
-            [KeyboardButton("Dynamics")],
-            [KeyboardButton("Back"), KeyboardButton("Cancel")],
+            [KeyboardButton("Account groups"), KeyboardButton("Structure")],
+            [KeyboardButton("Dynamics"), KeyboardButton("Back")],
+            [KeyboardButton("Cancel")],
         ]
         return ReplyKeyboardMarkup(buttons, resize_keyboard=True)
 
     def dashboard_group_menu_keyboard(self) -> ReplyKeyboardMarkup:
         buttons = [
-            [KeyboardButton("Accounts")],
-            [KeyboardButton("Structure")],
-            [KeyboardButton("Dynamics")],
-            [KeyboardButton("Back"), KeyboardButton("Cancel")],
+            [KeyboardButton("Accounts"), KeyboardButton("Structure")],
+            [KeyboardButton("Dynamics"), KeyboardButton("Back")],
+            [KeyboardButton("Cancel")],
         ]
         return ReplyKeyboardMarkup(buttons, resize_keyboard=True)
 


### PR DESCRIPTION
## Summary
- standardize layout of account and group dashboards to show two buttons per row

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856ff1e7e7c8332be8e3f13f7cadd03