### PR TITLE
Restructure capital account type

### DIFF
--- a/foremoney/constants.py
+++ b/foremoney/constants.py
@@ -33,8 +33,20 @@ ACCOUNT_GROUPS = {
         "Salary",
     ],
     "capital": [
-        "Initial values",
-        "Monthly result",
+        "assets",
+        "liabilities",
+        "expenditures",
+        "income",
         "Corrections",
     ],
+}
+
+# Mapping of capital account groups to subordinate account names.
+# Each capital group mirrors the account groups from the respective
+# account type.
+CAPITAL_ACCOUNTS = {
+    "assets": ACCOUNT_GROUPS["assets"],
+    "liabilities": ACCOUNT_GROUPS["liabilities"],
+    "expenditures": ACCOUNT_GROUPS["expenditures"],
+    "income": ACCOUNT_GROUPS["income"],
 }

--- a/foremoney/init_data.py
+++ b/foremoney/init_data.py
@@ -1,5 +1,5 @@
 from .database import Database
-from .constants import ACCOUNT_TYPES, ACCOUNT_GROUPS
+from .constants import ACCOUNT_TYPES, ACCOUNT_GROUPS, CAPITAL_ACCOUNTS
 
 
 def seed(db: Database, user_id: int) -> None:
@@ -30,3 +30,22 @@ def seed(db: Database, user_id: int) -> None:
                     """,
                     (user_id, type_id, group),
                 )
+        if atype == "capital":
+            for group in groups:
+                group_row = db.fetchone(
+                    "SELECT id FROM account_groups WHERE user_id=? AND type_id=? AND name=?",
+                    (user_id, type_id, group),
+                )
+                if not group_row:
+                    continue
+                gid = group_row["id"]
+                for acc in CAPITAL_ACCOUNTS.get(group, []):
+                    acc_exists = db.fetchone(
+                        "SELECT 1 FROM accounts WHERE user_id=? AND group_id=? AND name=?",
+                        (user_id, gid, acc),
+                    )
+                    if not acc_exists:
+                        db.execute(
+                            "INSERT INTO accounts (user_id, group_id, name) VALUES (?, ?, ?)",
+                            (user_id, gid, acc),
+                        )


### PR DESCRIPTION
## Summary
- adjust the default account groups for the `capital` type
- link new capital groups to the groups of other account types
- seed default capital accounts when initializing data

## Testing
- `python -m py_compile foremoney/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68570b7fe73c8332b4159dd5bc7d010d