### PR TITLE
Improve account creation

### DIFF
--- a/foremoney/bot.py
+++ b/foremoney/bot.py
@@ -46,6 +46,7 @@ class FinanceBot(
                 AMOUNT: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.amount)],
                 TX_DATETIME: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.tx_datetime)],
                 ADD_ACCOUNT_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.add_account_name)],
+                ADD_ACCOUNT_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.add_account_value)],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
             allow_reentry=True,

--- a/foremoney/states.py
+++ b/foremoney/states.py
@@ -8,6 +8,7 @@
     TO_ACCOUNT,
     AMOUNT,
     ADD_ACCOUNT_NAME,
+    ADD_ACCOUNT_VALUE,
     TX_LIST,
     TX_DETAILS,
     TX_EDIT_AMOUNT,
@@ -29,4 +30,4 @@
     DASH_ACC_MENU,
     DASH_GROUP_SELECT,
     DASH_GROUP_MENU,
-) = range(29)
+) = range(30)


### PR DESCRIPTION
## Summary
- ask for account's initial value when creating accounts
- sync capital accounts when adding accounts during transaction flow
- hide `+ account` for capital groups
- prohibit manual account creation in capital groups

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68582dd5cf8c8332a3540e2a9c3010cd