### PR TITLE
Improve transaction display

### DIFF
--- a/foremoney/constants.py
+++ b/foremoney/constants.py
@@ -6,6 +6,15 @@ ACCOUNT_TYPES = [
     "capital",
 ]
 
+# Short codes for account types used in transaction descriptions
+ACCOUNT_TYPE_CODES = {
+    "assets": "A",
+    "expenditures": "E",
+    "liabilities": "L",
+    "income": "I",
+    "capital": "C",
+}
+
 ACCOUNT_GROUPS = {
     "assets": [
         "cash",

--- a/foremoney/database.py
+++ b/foremoney/database.py
@@ -139,10 +139,16 @@ class Database:
         return self.fetchall(
             """
             SELECT t.id, t.amount, t.ts,
-                   fa.name AS from_name, ta.name AS to_name
+                   fa.name AS from_name, ta.name AS to_name,
+                   fg.name AS from_group, tg.name AS to_group,
+                   ft.name AS from_type, tt.name AS to_type
             FROM transactions t
             JOIN accounts fa ON fa.id=t.from_account
+            JOIN account_groups fg ON fa.group_id=fg.id
+            JOIN account_types ft ON fg.type_id=ft.id
             JOIN accounts ta ON ta.id=t.to_account
+            JOIN account_groups tg ON ta.group_id=tg.id
+            JOIN account_types tt ON tg.type_id=tt.id
             WHERE t.user_id=?
             ORDER BY t.id DESC
             LIMIT ? OFFSET ?
@@ -154,10 +160,16 @@ class Database:
         return self.fetchone(
             """
             SELECT t.id, t.amount, t.ts,
-                   fa.name AS from_name, ta.name AS to_name
+                   fa.name AS from_name, ta.name AS to_name,
+                   fg.name AS from_group, tg.name AS to_group,
+                   ft.name AS from_type, tt.name AS to_type
             FROM transactions t
             JOIN accounts fa ON fa.id=t.from_account
+            JOIN account_groups fg ON fa.group_id=fg.id
+            JOIN account_types ft ON fg.type_id=ft.id
             JOIN accounts ta ON ta.id=t.to_account
+            JOIN account_groups tg ON ta.group_id=tg.id
+            JOIN account_types tt ON tg.type_id=tt.id
             WHERE t.user_id=? AND t.id=?
             """,
             (user_id, tx_id),

--- a/foremoney/transactions/create.py
+++ b/foremoney/transactions/create.py
@@ -22,7 +22,7 @@ from ..states import (
     ADD_ACCOUNT_VALUE,
     TX_DATETIME,
 )
-from .helpers import make_labels, labels_map
+from .helpers import make_labels, labels_map, format_transaction
 
 class TransactionCreateMixin:
     """Flow for creating a transaction."""
@@ -468,7 +468,7 @@ class TransactionCreateMixin:
             self.db.update_transaction_amount(user_id, tx_id, amount)
             tx = self.db.transaction(user_id, tx_id)
             await update.message.reply_text(
-                f"{tx['from_name']} - {tx['amount']} -> {tx['to_name']}"
+                format_transaction(tx)
             )
             await update.message.reply_text(
                 "Transaction saved", reply_markup=self.main_menu_keyboard()
@@ -522,7 +522,7 @@ class TransactionCreateMixin:
         )
         tx = self.db.transaction(user_id, tx_id)
         await update.message.reply_text(
-            f"{tx['from_name']} - {tx['amount']} -> {tx['to_name']}"
+            format_transaction(tx)
         )
         await update.message.reply_text(
             "Transaction saved", reply_markup=self.main_menu_keyboard()

--- a/foremoney/transactions/helpers.py
+++ b/foremoney/transactions/helpers.py
@@ -14,3 +14,16 @@ def make_labels(items: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
 def labels_map(labels: Iterable[Mapping[str, Any]]) -> dict[str, int]:
     """Map label name to original id."""
     return {lbl["name"]: lbl["id"] for lbl in labels}
+
+
+def format_transaction(tx: Mapping[str, Any]) -> str:
+    """Return short description of a transaction for inline buttons."""
+    from ..constants import ACCOUNT_TYPE_CODES
+
+    f_code = ACCOUNT_TYPE_CODES.get(tx["from_type"], "?")
+    t_code = ACCOUNT_TYPE_CODES.get(tx["to_type"], "?")
+    return (
+        f"{f_code}-{tx['from_group']}-{tx['from_name']} "
+        f"-{tx['amount']}-> "
+        f"{t_code}-{tx['to_group']}-{tx['to_name']}"
+    )

--- a/foremoney/transactions/list.py
+++ b/foremoney/transactions/list.py
@@ -1,6 +1,8 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes, ConversationHandler
 
+from .helpers import format_transaction
+
 from ..states import TX_LIST, TX_DETAILS, TX_EDIT_AMOUNT
 
 class TransactionListMixin:
@@ -14,7 +16,7 @@ class TransactionListMixin:
         txs = self.db.transactions(user_id, 10, offset)
         buttons = [
             [InlineKeyboardButton(
-                f"{tx['from_name']} - {tx['amount']} -> {tx['to_name']}",
+                format_transaction(tx),
                 callback_data=f"tx:{tx['id']}"
             )]
             for tx in txs
@@ -44,7 +46,7 @@ class TransactionListMixin:
                 return TX_LIST
             context.user_data["tx_id"] = tx_id
             await query.message.reply_text(
-                f"{tx['from_name']} - {tx['amount']} -> {tx['to_name']}",
+                format_transaction(tx),
                 reply_markup=InlineKeyboardMarkup(
                     [
                         [InlineKeyboardButton("Edit", callback_data="edit")],
@@ -82,7 +84,7 @@ class TransactionListMixin:
             self.db.update_transaction_amount(user_id, tx_id, amount)
             tx = self.db.transaction(user_id, tx_id)
             await update.message.reply_text(
-                f"{tx['from_name']} - {tx['amount']} -> {tx['to_name']}",
+                format_transaction(tx),
                 reply_markup=InlineKeyboardMarkup(
                     [
                         [InlineKeyboardButton("Edit", callback_data="edit")],


### PR DESCRIPTION
## Summary
- add short code mapping for account types
- helper to format transactions
- include account group/type data in transaction queries
- show formatted transaction description in lists and creation flows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68585825eea4833299584d6763e7b073