### PR TITLE
Add cancel option in settings submenus

### DIFF
--- a/foremoney/bot.py
+++ b/foremoney/bot.py
@@ -89,6 +89,7 @@ class FinanceBot(
                 DASHBOARD_ACCOUNTS: [
                     CallbackQueryHandler(self.toggle_dashboard_account, pattern="^dashacc:"),
                     CallbackQueryHandler(self.save_dashboard_accounts, pattern="^dashsave$"),
+                    CallbackQueryHandler(self.cancel_settings_submenu, pattern="^dashcancel$"),
                     MessageHandler(filters.TEXT & ~filters.COMMAND, self.settings_menu),
                 ],
                 AG_TYPE_SELECT: [

--- a/foremoney/settings_accounts.py
+++ b/foremoney/settings_accounts.py
@@ -35,11 +35,16 @@ class SettingsAccountsMixin:
         extra: list[str] = []
         if not row or row["type_name"] != "capital":
             extra.append("+ account")
-        extra.extend(["Rename group", "Delete group", "Back"])
+        extra.extend(["Rename group", "Delete group", "Back", "Cancel"])
         return items_reply_keyboard(labels, extra, columns=2)
 
     async def acc_select(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         acc_map = context.user_data.get("ag_account_map", {})
         if text not in acc_map:
             await update.message.reply_text("Use provided buttons")
@@ -56,6 +61,7 @@ class SettingsAccountsMixin:
                     [KeyboardButton("Rename")],
                     [KeyboardButton("Delete")],
                     [KeyboardButton("Back")],
+                    [KeyboardButton("Cancel")],
                 ],
                 resize_keyboard=True,
             ),
@@ -83,6 +89,11 @@ class SettingsAccountsMixin:
 
     async def acc_add_name(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         name = update.message.text.strip()
+        if name == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         gid = context.user_data["group_id"]
         user_id = update.effective_user.id
         acc_id = self.db.add_account(user_id, gid, name)
@@ -92,6 +103,11 @@ class SettingsAccountsMixin:
 
     async def acc_add_value(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         text = update.message.text.strip()
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         try:
             value = float(text)
         except ValueError:
@@ -177,6 +193,11 @@ class SettingsAccountsMixin:
 
     async def account_rename(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         name = update.message.text.strip()
+        if name == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         aid = context.user_data["account_id"]
         user_id = update.effective_user.id
         self.db.update_account_name(user_id, aid, name)
@@ -201,6 +222,11 @@ class SettingsAccountsMixin:
         return AG_ACCOUNTS
 
     async def account_menu_back(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        if update.message.text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         gid = context.user_data["group_id"]
         keyboard = self.accounts_keyboard(update.effective_user.id, gid, context.user_data)
         await update.message.reply_text(

--- a/foremoney/settings_dashboard.py
+++ b/foremoney/settings_dashboard.py
@@ -54,6 +54,7 @@ class SettingsDashboardMixin:
             label = f"{prefix}{acc['group_name']}: {acc['name']}"
             buttons.append([InlineKeyboardButton(label, callback_data=f"dashacc:{acc['id']}")])
         buttons.append([InlineKeyboardButton("Save", callback_data="dashsave")])
+        buttons.append([InlineKeyboardButton("Cancel", callback_data="dashcancel")])
         return InlineKeyboardMarkup(buttons)
 
     async def start_dashboard_accounts(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -91,6 +92,19 @@ class SettingsDashboardMixin:
         self.db.set_setting(user_id, "dashboard_accounts", val)
         await query.message.reply_text("Saved", reply_markup=self.settings_menu_keyboard())
         return SETTINGS_MENU
+
+    async def cancel_settings_submenu(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        query = update.callback_query
+        if query:
+            await query.answer()
+            await query.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+        else:
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+        return ConversationHandler.END
 
     async def recreate_database(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         user_id = update.effective_user.id

--- a/foremoney/settings_groups.py
+++ b/foremoney/settings_groups.py
@@ -22,7 +22,7 @@ class SettingsGroupsMixin:
     """Manage account group operations."""
 
     def account_groups_keyboard(self, labels: list[dict[str, str]]) -> ReplyKeyboardMarkup:
-        return items_reply_keyboard(labels, ["+ group", "Back"], columns=2)
+        return items_reply_keyboard(labels, ["+ group", "Back", "Cancel"], columns=2)
 
     async def start_account_groups(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         user_id = update.effective_user.id
@@ -32,12 +32,17 @@ class SettingsGroupsMixin:
         context.user_data["ag_type_map"] = labels_map(type_labels)
         await update.message.reply_text(
             "Select account type",
-            reply_markup=items_reply_keyboard(type_labels, ["Back"], columns=2),
+            reply_markup=items_reply_keyboard(type_labels, ["Back", "Cancel"], columns=2),
         )
         return AG_TYPE_SELECT
 
     async def ag_type_selected(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         text = update.message.text
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         if text == "Back":
             await self.start_settings(update, context)
             return SETTINGS_MENU
@@ -62,6 +67,11 @@ class SettingsGroupsMixin:
 
     async def ag_add_group_name(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         name = update.message.text.strip()
+        if name == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         user_id = update.effective_user.id
         type_id = context.user_data["atype"]
         self.db.add_account_group(user_id, type_id, name)
@@ -77,6 +87,11 @@ class SettingsGroupsMixin:
     async def ag_select_group(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         text = update.message.text
         user_id = update.effective_user.id
+        if text == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         if text == "Back":
             types = self.db.account_types_with_value(user_id)
             type_labels = make_labels(types)
@@ -134,6 +149,11 @@ class SettingsGroupsMixin:
 
     async def grename(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         name = update.message.text.strip()
+        if name == "Cancel":
+            await update.message.reply_text(
+                "Cancelled", reply_markup=self.main_menu_keyboard()
+            )
+            return ConversationHandler.END
         gid = context.user_data["group_id"]
         user_id = update.effective_user.id
         self.db.update_account_group_name(user_id, gid, name)


### PR DESCRIPTION
## Summary
- add Cancel button to account group/account management keyboards
- add Cancel callback for dashboard account selection
- support Cancel text in settings handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68585e0f699c83328229a6fef1fe4034