### PR TITLE
Fix settings cancel to reset session

### DIFF
--- a/foremoney/menu.py
+++ b/foremoney/menu.py
@@ -7,7 +7,10 @@ class MenuMixin:
     """Main menu and basic commands."""
 
     async def cancel(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-        await update.message.reply_text("Cancelled")
+        context.user_data.clear()
+        await update.message.reply_text(
+            "Cancelled", reply_markup=self.main_menu_keyboard()
+        )
         return ConversationHandler.END
 
     async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/foremoney/settings_accounts.py
+++ b/foremoney/settings_accounts.py
@@ -44,6 +44,7 @@ class SettingsAccountsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         acc_map = context.user_data.get("ag_account_map", {})
         if text not in acc_map:
@@ -93,6 +94,7 @@ class SettingsAccountsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         gid = context.user_data["group_id"]
         user_id = update.effective_user.id
@@ -107,6 +109,7 @@ class SettingsAccountsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         try:
             value = float(text)
@@ -197,6 +200,7 @@ class SettingsAccountsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         aid = context.user_data["account_id"]
         user_id = update.effective_user.id
@@ -226,6 +230,7 @@ class SettingsAccountsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         gid = context.user_data["group_id"]
         keyboard = self.accounts_keyboard(update.effective_user.id, gid, context.user_data)

--- a/foremoney/settings_dashboard.py
+++ b/foremoney/settings_dashboard.py
@@ -104,6 +104,7 @@ class SettingsDashboardMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+        context.user_data.clear()
         return ConversationHandler.END
 
     async def recreate_database(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:

--- a/foremoney/settings_groups.py
+++ b/foremoney/settings_groups.py
@@ -42,6 +42,7 @@ class SettingsGroupsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         if text == "Back":
             await self.start_settings(update, context)
@@ -71,6 +72,7 @@ class SettingsGroupsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         user_id = update.effective_user.id
         type_id = context.user_data["atype"]
@@ -91,6 +93,7 @@ class SettingsGroupsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         if text == "Back":
             types = self.db.account_types_with_value(user_id)
@@ -153,6 +156,7 @@ class SettingsGroupsMixin:
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()
             )
+            context.user_data.clear()
             return ConversationHandler.END
         gid = context.user_data["group_id"]
         user_id = update.effective_user.id


### PR DESCRIPTION
## Summary
- reset user_data when cancelling settings
- ensure keyboard returns to main menu

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68586130ed9c8332a6384ae6a73f93a4