### PR TITLE
Fix ConversationHandler NameError

### DIFF
--- a/foremoney/settings_accounts.py
+++ b/foremoney/settings_accounts.py
@@ -4,7 +4,7 @@ from telegram import (
     ReplyKeyboardRemove,
     KeyboardButton,
 )
-from telegram.ext import ContextTypes
+from telegram.ext import ContextTypes, ConversationHandler
 
 from .ui import items_reply_keyboard
 


### PR DESCRIPTION
## Summary
- import `ConversationHandler` in `settings_accounts.py`

## Testing
- `python -m compileall foremoney`
- `python -m py_compile foremoney/settings_accounts.py`


------
https://chatgpt.com/codex/tasks/task_e_6859a9ba2654833284fc246fed6c610d