### PR TITLE
Implement basic family invitation

### DIFF
--- a/foremoney/bot.py
+++ b/foremoney/bot.py
@@ -16,6 +16,7 @@ from .transactions import TransactionCreateMixin, TransactionListMixin
 from .settings_dashboard import SettingsDashboardMixin
 from .settings_groups import SettingsGroupsMixin
 from .settings_accounts import SettingsAccountsMixin
+from .settings_family import SettingsFamilyMixin
 
 
 class FinanceBot(
@@ -25,6 +26,7 @@ class FinanceBot(
     SettingsDashboardMixin,
     SettingsGroupsMixin,
     SettingsAccountsMixin,
+    SettingsFamilyMixin,
     MenuMixin,
 ):
     def __init__(self) -> None:

--- a/foremoney/dashboard.py
+++ b/foremoney/dashboard.py
@@ -68,7 +68,7 @@ class DashboardMixin:
             )
             return DASH_MENU
         if text == "Accounts":
-            seed(self.db, user_id)
+            seed(self.db, self.db.family_id(user_id))
             types = self.db.account_types_with_value(user_id)
             type_labels = make_labels(types)
             context.user_data["dash_type_map"] = labels_map(type_labels)

--- a/foremoney/menu.py
+++ b/foremoney/menu.py
@@ -15,7 +15,13 @@ class MenuMixin:
 
     async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         user_id = update.effective_user.id
-        seed(self.db, user_id)
+        if context.args and context.args[0].startswith("join_"):
+            token = context.args[0][5:]
+            if self.db.use_family_invite(token, user_id):
+                await update.message.reply_text("You joined the family!")
+            else:
+                await update.message.reply_text("Invalid invite link")
+        seed(self.db, self.db.family_id(user_id))
         await update.message.reply_text(
             "Welcome to ForeMoney bot!",
             reply_markup=self.main_menu_keyboard(),

--- a/foremoney/settings_dashboard.py
+++ b/foremoney/settings_dashboard.py
@@ -22,7 +22,10 @@ class SettingsDashboardMixin:
                 KeyboardButton("Accounts"),
             ],
             [
+                KeyboardButton("Add family"),
                 KeyboardButton("Recreate database"),
+            ],
+            [
                 KeyboardButton("Back"),
             ],
         ]
@@ -40,6 +43,8 @@ class SettingsDashboardMixin:
             return await self.start_dashboard_accounts(update, context)
         if text == "Accounts":
             return await self.start_account_groups(update, context)
+        if text == "Add family":
+            return await self.invite_family(update, context)
         if text == "Recreate database":
             return await self.recreate_database(update, context)
         if text == "Back":
@@ -117,6 +122,6 @@ class SettingsDashboardMixin:
         if self.settings.database_path.exists():
             self.settings.database_path.unlink()
         self.db = Database(self.settings.database_path)
-        seed(self.db, user_id)
+        seed(self.db, self.db.family_id(user_id))
         await update.message.reply_text("Database recreated")
         return SETTINGS_MENU

--- a/foremoney/settings_family.py
+++ b/foremoney/settings_family.py
@@ -1,0 +1,18 @@
+from telegram import Update
+from telegram.ext import ContextTypes
+from .states import SETTINGS_MENU
+
+class SettingsFamilyMixin:
+    """Family invitation management."""
+
+    async def invite_family(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+        user_id = update.effective_user.id
+        family_id = self.db.family_id(user_id)
+        token = self.db.create_family_invite(family_id)
+        bot_username = (await context.bot.get_me()).username
+        link = f"https://t.me/{bot_username}?start=join_{token}"
+        await update.message.reply_text(
+            "Forward this message to a family member to join your finances:\n" + link
+        )
+        return SETTINGS_MENU
+

--- a/foremoney/settings_groups.py
+++ b/foremoney/settings_groups.py
@@ -26,7 +26,7 @@ class SettingsGroupsMixin:
 
     async def start_account_groups(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         user_id = update.effective_user.id
-        seed(self.db, user_id)
+        seed(self.db, self.db.family_id(user_id))
         types = self.db.account_types_with_value(user_id)
         type_labels = make_labels(types)
         context.user_data["ag_type_map"] = labels_map(type_labels)

--- a/foremoney/transactions/create.py
+++ b/foremoney/transactions/create.py
@@ -29,7 +29,8 @@ class TransactionCreateMixin:
 
     async def start_create_transaction(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         user_id = update.effective_user.id
-        seed(self.db, user_id)
+        family_id = self.db.family_id(user_id)
+        seed(self.db, family_id)
         types = self.db.account_types_with_value(user_id)
         type_labels = make_labels(types)
         context.user_data["from_type_map"] = labels_map(type_labels)


### PR DESCRIPTION
## Summary
- enable joining a family via `/start` parameter
- add database tables for families and map users to a family
- send deep-link invitation from new `Add family` menu option
- ensure seed operations use family id

## Testing
- `python -m py_compile foremoney/*.py foremoney/transactions/*.py`
- `python bot-start-foremoney.py -h` *(fails: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_6859b5e059288332a0466675147e83c4