### PR TITLE
Improve transaction list details

### DIFF
--- a/foremoney/transactions/helpers.py
+++ b/foremoney/transactions/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable, Mapping, Any
+from datetime import datetime
 
 
 def make_labels(items: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
@@ -26,4 +27,20 @@ def format_transaction(tx: Mapping[str, Any]) -> str:
         f"{f_code}-{tx['from_group']}-{tx['from_name']} "
         f"-{tx['amount']}-> "
         f"{t_code}-{tx['to_group']}-{tx['to_name']}"
+    )
+
+
+def transaction_summary(tx: Mapping[str, Any]) -> str:
+    """Return multiline summary of a transaction for list view."""
+    if tx.get("ts"):
+        try:
+            date = datetime.fromisoformat(str(tx["ts"])).strftime("%Y-%m-%d")
+        except ValueError:
+            date = str(tx["ts"])[:10]
+    else:
+        date = ""
+    return (
+        f"from: {tx['from_group']} - {tx['from_name']}\n"
+        f"to: {tx['to_group']} - {tx['to_name']}\n"
+        f"amount: {tx['amount']}, date: {date}"
     )

--- a/foremoney/transactions/list.py
+++ b/foremoney/transactions/list.py
@@ -1,7 +1,7 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes, ConversationHandler
 
-from .helpers import format_transaction
+from .helpers import format_transaction, transaction_summary
 
 from ..states import TX_LIST, TX_DETAILS, TX_EDIT_AMOUNT
 
@@ -15,10 +15,11 @@ class TransactionListMixin:
         msg_obj = sender if hasattr(sender, "reply_text") else sender.message
         txs = self.db.transactions(user_id, 10, offset)
         buttons = [
-            [InlineKeyboardButton(
-                format_transaction(tx),
-                callback_data=f"tx:{tx['id']}"
-            )]
+            [
+                InlineKeyboardButton(
+                    transaction_summary(tx), callback_data=f"tx:{tx['id']}"
+                )
+            ]
             for tx in txs
         ]
         if txs:


### PR DESCRIPTION
## Summary
- add `transaction_summary` helper to display formatted transaction info
- show transaction summary when listing transactions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68696ede8cf88332861b259690f6f618