### PR TITLE
Fix transaction summary for sqlite rows

### DIFF
--- a/foremoney/transactions/helpers.py
+++ b/foremoney/transactions/helpers.py
@@ -32,15 +32,16 @@ def format_transaction(tx: Mapping[str, Any]) -> str:
 
 def transaction_summary(tx: Mapping[str, Any]) -> str:
     """Return multiline summary of a transaction for list view."""
-    if tx.get("ts"):
+    data = dict(tx)
+    if data.get("ts"):
         try:
-            date = datetime.fromisoformat(str(tx["ts"])).strftime("%Y-%m-%d")
+            date = datetime.fromisoformat(str(data["ts"])).strftime("%Y-%m-%d")
         except ValueError:
-            date = str(tx["ts"])[:10]
+            date = str(data["ts"])[:10]
     else:
         date = ""
     return (
-        f"from: {tx['from_group']} - {tx['from_name']}\n"
-        f"to: {tx['to_group']} - {tx['to_name']}\n"
-        f"amount: {tx['amount']}, date: {date}"
+        f"from: {data['from_group']} - {data['from_name']}\n"
+        f"to: {data['to_group']} - {data['to_name']}\n"
+        f"amount: {data['amount']}, date: {date}"
     )


### PR DESCRIPTION
## Summary
- normalize transaction objects to dict before generating summary

## Testing
- `python -m py_compile foremoney/transactions/helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68697126c7c88332a9aa22e88ba834da