### PR TITLE
Fix transaction filtering submenu re-entry

### DIFF
--- a/foremoney/transactions/list.py
+++ b/foremoney/transactions/list.py
@@ -59,6 +59,8 @@ class TransactionListMixin:
 
     async def tx_filter_menu(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         text = update.message.text
+        if text == "Transactions":
+            return await self.start_transactions(update, context)
         if text == "Cancel":
             await update.message.reply_text(
                 "Cancelled", reply_markup=self.main_menu_keyboard()


### PR DESCRIPTION
## Summary
- handle `Transactions` text in transaction list filter menu so that the
  filtering submenu can be reopened without leaving the conversation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 foremoney | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68697f28f1d48332993094af4687bfdb