### PR TITLE
Add Food expenditure group

### DIFF
--- a/foremoney/constants.py
+++ b/foremoney/constants.py
@@ -28,6 +28,7 @@ ACCOUNT_GROUPS = {
         "Education",
         "Living space",
         "Entertainment",
+        "Food",
         "Transport",
         "Health & Sport",
         "Culture",


### PR DESCRIPTION
## Summary
- add a new `Food` group under the `expenditures` account type

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6869858c0c808332903fa6dba145d7b8