### PR TITLE
Add export/import data features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ implements transaction management, dashboard charts and a settings section.
   selecting which accounts appear on the dashboard.
 - SQLite database for storing all data. The database structure is created
   automatically and can be recreated from the Settings menu.
+- Data export/import of the entire database via a zipped collection of CSV files.
 - `.env` configuration using `python-dotenv`.
 - `deploy.sh` script installs dependencies in a virtual environment and
   configures a systemd service.

--- a/foremoney/bot.py
+++ b/foremoney/bot.py
@@ -130,6 +130,10 @@ class FinanceBot(
                     MessageHandler(filters.TEXT & ~filters.COMMAND, self.account_menu_back),
                 ],
                 ACCOUNT_RENAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, self.account_rename)],
+                IMPORT_WAIT_FILE: [
+                    MessageHandler(filters.Document.ALL, self.import_data_file),
+                    MessageHandler(filters.TEXT & ~filters.COMMAND, self.import_data_file),
+                ],
             },
             fallbacks=[CommandHandler("cancel", self.cancel)],
         )

--- a/foremoney/states.py
+++ b/foremoney/states.py
@@ -37,4 +37,5 @@
     TX_FILTER_ACC_TYPE,
     TX_FILTER_GROUP,
     TX_FILTER_ACCOUNT,
-) = range(37)
+    IMPORT_WAIT_FILE,
+) = range(38)


### PR DESCRIPTION
## Summary
- allow exporting database to a zip with CSV tables
- allow importing such archive to replace the DB
- add `IMPORT_WAIT_FILE` state and handlers
- document data export/import in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68698c201fb8833295a681a525e22a70